### PR TITLE
Add sim_resp to er_simulate.erglm_model() for er_vpc_plot(model = ...)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,23 @@ references the old package/function names (`erlr::lr_model()`,
 vignette article -- it needs a corresponding update once this rename is
 published, or its `erlr`-dependent tests/vignette will break.
 
+**`sim_resp` addition (this branch, not yet merged).** erplots'
+`er_vpc_plot()` used to require a bespoke, model-package-specific
+simulation helper (`erglm_vpc_sim()`) rather than going through the
+shared `er_predict()`/`er_simulate()`/`er_summary()` interface -- a
+design gap on the erplots side. It was closed by widening erplots'
+`er_simulate()` contract (additively: a method may now return an
+optional `sim_resp` column alongside `fit_resp`) rather than adding a
+new generic, since `.erglm_simulate_draws()` and
+`.erglm_draw_response()` already had everything needed to compute a
+full response-level draw -- see erplots'
+`?erplots::er_model_interface` for the contract this satisfies.
+`er_simulate.erglm_model()` (`R/er-methods.R`) needed no change itself;
+only its `.erglm_simulate_draws()` engine did.
+`erglm_vpc_sim()`/`simulate.erglm_model()`/`.erglm_resample()` are
+unaffected and still work exactly as before -- they're a separate code
+path, not a caller of `.erglm_simulate_draws()`.
+
 ## Planned work
 
 See [PLAN.md](PLAN.md) for the history of this generalisation/rename
@@ -78,13 +95,24 @@ Started" stub are all now done. One item remains: the companion
 
 - `R/erglm-core.R` -- `erglm_model()`, `erglm_predict()`, the
   `erglm_fun()` closure factory, and the shared
-  `.erglm_simulate_draws()` helper (used by both `erglm_vpc_sim()` and,
-  via erplots, spaghetti-style plots). When `.erglm_simulate_draws()`
-  auto-picks a seed (`seed = NULL`, via `.pick_seed()`), it reports
-  this via `rlang::inform()` -- e.g. `"Using seed = 1234. Pass \`seed =
+  `.erglm_simulate_draws()` helper (used directly by
+  `er_simulate.erglm_model()`, and indirectly -- via
+  `simulate.erglm_model()`/`.erglm_resample()` in `R/erglm-simulate.R`
+  -- by `erglm_vpc_sim()`). Its output carries both `fit_resp` (the
+  expected response at a sampled parameter vector -- parameter
+  uncertainty only, used by erplots' spaghetti-style plots) and
+  `sim_resp` (that same `fit_resp` plus family-appropriate residual
+  noise, via `.erglm_draw_response()` -- used by erplots'
+  `er_vpc_plot(model = ...)`), matching erplots' `er_simulate()`
+  contract (see `?erplots::er_model_interface`): a method may supply
+  `fit_resp` alone, or both columns from one call, and this package now
+  does the latter, computing both from the same sampled coefficient
+  draws for consistency. When `.erglm_simulate_draws()` auto-picks a
+  seed (`seed = NULL`, via `.pick_seed()`), it reports this via
+  `rlang::inform()` -- e.g. `"Using seed = 1234. Pass \`seed =
   1234\` to reproduce this result."` -- because the seed genuinely
-  determines the random coefficient draws returned, unlike the SCM
-  functions below.
+  determines the random coefficient *and* response draws returned,
+  unlike the SCM functions below.
 - `R/erglm-scm.R` -- forward/backward stepwise covariate modelling
   (`erglm_scm_forward()`/`erglm_scm_backward()`/`erglm_scm_history()`),
   and the single-term `erglm_add_term()`/`erglm_remove_term()` helpers

--- a/R/erglm-core.R
+++ b/R/erglm-core.R
@@ -149,15 +149,23 @@ erglm_fun <- function(object) {
 # shared helper: draws `nsim` sets of coefficients from the sampling
 # distribution implied by the model's variance-covariance matrix, and
 # evaluates the linear predictor at each draw for the supplied `newdata`.
-# Used both by `erglm_vpc_sim()` and by the `er_simulate.erglm_model()`
-# method (used by erplots, if installed, for spaghetti-style uncertainty
-# bands).
+# Used by `erglm_vpc_sim()` (indirectly, via `simulate.erglm_model()`/
+# `.erglm_resample()` -- see erglm-simulate.R) and directly by the
+# `er_simulate.erglm_model()` method (used by erplots, if installed, for
+# both spaghetti-style uncertainty bands via `fit_resp`, and for
+# `er_vpc_plot(model = ...)` via `sim_resp` -- see `?er_model_interface`
+# in erplots for the distinction between the two columns). `sim_resp` adds
+# family-appropriate residual/dispersion noise on top of `fit_resp`, via
+# the same `.erglm_draw_response()` helper `.erglm_resample()` itself
+# uses, so both simulation entry points share one noise model.
 .erglm_simulate_draws <- function(object, newdata, nsim = 100, seed = NULL) {
   if (is.null(seed)) {
     seed <- .pick_seed()
     rlang::inform(paste0("Using seed = ", seed, ". Pass `seed = ", seed, "` to reproduce this result."))
   }
   fn <- erglm_fun(object)
+  family_name <- stats::family(object)$family
+  dispersion <- summary(object)$dispersion
   withr::with_seed(
     seed = seed,
     code = {
@@ -166,14 +174,15 @@ erglm_fun <- function(object) {
         mean = stats::coef(object),
         sigma = stats::vcov(object)
       )
+      sim <- list()
+      for (ii in seq_len(nsim)) {
+        dd_sim <- newdata |> dplyr::mutate(row_id = dplyr::row_number(), sim_id = ii)
+        dd_sim$fit_resp <- fn(param = par[ii, ], dd_sim)
+        dd_sim$sim_resp <- .erglm_draw_response(family_name, fit = dd_sim$fit_resp, dispersion = dispersion)
+        sim[[ii]] <- dd_sim
+      }
     }
   )
-  sim <- list()
-  for (ii in seq_len(nsim)) {
-    dd_sim <- newdata |> dplyr::mutate(row_id = dplyr::row_number(), sim_id = ii)
-    dd_sim$fit_resp <- fn(param = par[ii, ], dd_sim)
-    sim[[ii]] <- dd_sim
-  }
   dplyr::bind_rows(sim)
 }
 

--- a/tests/testthat/test-er-methods.R
+++ b/tests/testthat/test-er-methods.R
@@ -9,6 +9,11 @@ test_that("erglm_model methods for erplots' generics are registered when erplots
   sim <- erplots::er_simulate(mod, erglm_data[1:5, ], nsim = 2, seed = 1)
   expect_s3_class(sim, "data.frame")
   expect_equal(nrow(sim), 10L)
+  # sim_resp is the erplots er_vpc_plot(model = ...) contract addition:
+  # a full response-scale draw (0/1 for a binomial model), not just the
+  # expected-response fit_resp
+  expect_true(all(c("fit_resp", "sim_resp") %in% names(sim)))
+  expect_true(all(sim$sim_resp %in% c(0, 1)))
 
   smm <- erplots::er_summary(mod)
   expect_true(is.list(smm))
@@ -39,4 +44,20 @@ test_that("er_summary extracts p-values generically across dispersion parameteri
   smm_pois <- erplots::er_summary(mod_pois)
   coefs_pois <- summary(mod_pois)$coefficients
   expect_equal(smm_pois$p_value, unname(coefs_pois[2, "Pr(>|z|)"]))
+})
+
+test_that("er_simulate()'s sim_resp column uses family-appropriate noise", {
+  skip_if_not_installed("erplots")
+
+  mod_gauss <- erglm_model(biomarker_change ~ aucss, erglm_data, family = gaussian())
+  sim_gauss <- erplots::er_simulate(mod_gauss, erglm_data[1:5, ], nsim = 3, seed = 2)
+  expect_true(all(c("fit_resp", "sim_resp") %in% names(sim_gauss)))
+  # continuous, unbounded-ish response -- shouldn't collapse onto fit_resp exactly
+  expect_false(isTRUE(all.equal(sim_gauss$sim_resp, sim_gauss$fit_resp)))
+
+  mod_pois <- erglm_model(ae_count ~ aucss, erglm_data, family = poisson())
+  sim_pois <- erplots::er_simulate(mod_pois, erglm_data[1:5, ], nsim = 3, seed = 3)
+  expect_true(all(c("fit_resp", "sim_resp") %in% names(sim_pois)))
+  expect_true(all(sim_pois$sim_resp == round(sim_pois$sim_resp)))
+  expect_true(all(sim_pois$sim_resp >= 0))
 })


### PR DESCRIPTION
## Summary

erplots' `er_vpc_plot()` previously required a bespoke, model-package-specific
simulation helper (`erglm_vpc_sim()`) rather than going through the shared
`er_predict()`/`er_simulate()`/`er_summary()` interface -- a design gap on the
erplots side. erplots closed this by widening its `er_simulate()` contract
*additively*: a method may now return an optional `sim_resp` column (a full
response-scale draw, including observation-level sampling/residual noise)
alongside the existing `fit_resp` (expected response under parameter
uncertainty only, used for spaghetti-style plots). See erplots'
`?er_model_interface` for the updated contract, and its `er_vpc_plot(model =
...)` argument, which requires `sim_resp`.

## Changes

- `.erglm_simulate_draws()` (the engine behind `er_simulate.erglm_model()`)
  now also computes `sim_resp`, reusing the existing `.erglm_draw_response()`
  helper -- the same family-appropriate noise model already used by
  `simulate.erglm_model()`/`erglm_vpc_sim()`. No new dependencies, no public
  API changes.
- Added test coverage in `test-er-methods.R` for `sim_resp`'s presence and
  basic sanity (binary values for a binomial model, non-negative integers for
  poisson, non-degenerate draws for gaussian).
- Updated `AGENTS.md`.

`erglm_vpc_sim()`/`simulate.erglm_model()`/`.erglm_resample()` are a separate
code path and are unaffected.

## Status

Not intended to merge immediately -- opening for review alongside the
corresponding erplots change.